### PR TITLE
Simplify getting authsource data from config

### DIFF
--- a/lib/Auth/Process/BaseFilter.php
+++ b/lib/Auth/Process/BaseFilter.php
@@ -129,8 +129,7 @@ abstract class BaseFilter extends \SimpleSAML\Auth\ProcessingFilter
             }
 
             // Get just the specified authsource config values
-            $authsource = $authsource->getConfigItem($config['authsource']);
-            $authsource = $authsource->toArray();
+            $authsource = $authsource->getArray($config['authsource']);
 
             // Make sure it is an ldap source
             // TODO: Support ldap:LDAPMulti, if possible


### PR DESCRIPTION
The code uses getConfigItem, which wraps a Configuration around the array, after which it extracts the array. I checked the code, there does not seem any processing or sanity checking in the Configuration class, so the wrapping step is entirely unnecessary. So let's get rid of it.