### PR TITLE
Prevent empty SAML attributes

### DIFF
--- a/lib/Auth/Process/AttributeAddUsersGroups.php
+++ b/lib/Auth/Process/AttributeAddUsersGroups.php
@@ -55,6 +55,11 @@ class AttributeAddUsersGroups extends BaseFilter
         // Get the users groups from LDAP
         $groups = $this->getGroups($attributes);
 
+        // If there are none, do not proceed
+        if (empty($groups)) {
+            return;
+        }
+
         // Make the array if it is not set already
         if (!isset($attributes[$map['groups']])) {
             $attributes[$map['groups']] = [];


### PR DESCRIPTION
When there is no result from the search, the group-attribute would still be created as an empty array, and therefore leading to an empty Attribute-tag in the SAML response.
While not necessarily wrong as per SAML-specification, it's still unnecessary token bloat.