### PR TITLE
Use base search for known DN lookup

### DIFF
--- a/lib/Auth/Source/Ldap.php
+++ b/lib/Auth/Source/Ldap.php
@@ -134,10 +134,12 @@ class Ldap extends UserPassBase
         }
 
         $ldapUtils->bind($ldapObject, $dn, $password);
-        $filter = sprintf('(distinguishedName=%s)', $dn);
+
+        $options['scope'] = 'base';
+        $filter = '(objectClass=*)';
 
         /** @psalm-var \Symfony\Component\Ldap\Entry $entry */
-        $entry = $ldapUtils->search($ldapObject, $searchBase, $filter, $options, false);
+        $entry = $ldapUtils->search($ldapObject, [$dn], $filter, $options, false);
 
         $attributes = $this->ldapConfig->getValue('attributes', []);
         if ($attributes === null) {


### PR DESCRIPTION
Performing a 'base' search using the DN as base is the standard way.

Using (distinguishedName=) as a filter is not universal – for example,
OpenLDAP uses entryDN instead.

And while OpenLDAP 2.6.x seems to *recognize* distinguishedName, it
gives a completely different result (applying the match to all
DN-containing attributes rather than to the entry's own DN) – so the
search gives 25 entries, none of which were the correct one.