### PR TITLE
Bugfix: Don't shadow $attributes

### DIFF
--- a/src/Auth/Process/AttributeAddFromLDAP.php
+++ b/src/Auth/Process/AttributeAddFromLDAP.php
@@ -116,7 +116,7 @@ class AttributeAddFromLDAP extends BaseFilter
 
         $this->connector->bind($this->searchUsername, $this->searchPassword);
 
-        $attributes = $this->config->getOptionalValue(
+        $wantedAttrs = $this->config->getOptionalValue(
             'attributes',
             // If specifically set to NULL return all attributes, if not set at all return nothing (safe default)
             in_array('attributes', $this->config->getOptions(), true) ? ['*'] : [],
@@ -125,7 +125,7 @@ class AttributeAddFromLDAP extends BaseFilter
         $options = [
             'scope' => $this->config->getOptionalString('search.scope', Query::SCOPE_SUB),
             'timeout' => $this->config->getOptionalInteger('timeout', 3),
-            'filter' => $attributes,
+            'filter' => $wantedAttrs,
         ];
 
         $entries = $this->connector->searchForMultiple(


### PR DESCRIPTION
This causes the configuration array to be copied to the SAML assertion attribute array (as $attributes is made a reference earlier in the function).

---

During auth, when the AttributeAddFromLDAP authproc is enabled, the following exception is thrown:

```
SimpleSAML\Error\Error: UNHANDLEDEXCEPTION
Backtrace:
2 src/SimpleSAML/Error/ExceptionHandler.php:35 (SimpleSAML\Error\ExceptionHandler::customExceptionHandler)
1 vendor/symfony/error-handler/ErrorHandler.php:541 (Symfony\Component\ErrorHandler\ErrorHandler::handleException)
0 [builtin] (N/A)
Caused by: TypeError: DOMElement::setAttribute(): Argument #2 ($value) must be of type string, int given
Backtrace:
21 vendor/simplesamlphp/saml2/src/SAML2/Assertion.php:1661 (DOMElement::setAttribute)
20 vendor/simplesamlphp/saml2/src/SAML2/Assertion.php:1661 (SAML2\Assertion::addAttributeStatement)
19 vendor/simplesamlphp/saml2/src/SAML2/Assertion.php:1497 (SAML2\Assertion::toXML)
18 vendor/simplesamlphp/saml2/src/SAML2/Response.php:89 (SAML2\Response::toUnsignedXML)
17 vendor/simplesamlphp/saml2/src/SAML2/Message.php:477 (SAML2\Message::toSignedXML)
16 vendor/simplesamlphp/saml2/src/SAML2/HTTPPost.php:36 (SAML2\HTTPPost::send)
15 modules/saml/src/IdP/SAML2.php:120 (SimpleSAML\Module\saml\IdP\SAML2::sendResponse)
14 [builtin] (call_user_func)
13 src/SimpleSAML/IdP.php:282 (SimpleSAML\IdP::postAuthProc)
12 src/SimpleSAML/IdP.php:328 (SimpleSAML\IdP::postAuth)
11 [builtin] (call_user_func)
10 src/SimpleSAML/Auth/Source.php:230 (SimpleSAML\Auth\Source::loginCompleted)
9 [builtin] (call_user_func)
8 src/SimpleSAML/Auth/Source.php:153 (SimpleSAML\Auth\Source::completeAuth)
7 modules/core/src/Auth/UserPassBase.php:317 (SimpleSAML\Module\core\Auth\UserPassBase::handleLogin)
6 modules/core/src/Controller/Login.php:216 (SimpleSAML\Module\core\Controller\Login::handleLogin)
5 modules/core/src/Controller/Login.php:116 (SimpleSAML\Module\core\Controller\Login::loginuserpass)
4 vendor/symfony/http-kernel/HttpKernel.php:163 (Symfony\Component\HttpKernel\HttpKernel::handleRaw)
3 vendor/symfony/http-kernel/HttpKernel.php:75 (Symfony\Component\HttpKernel\HttpKernel::handle)
2 vendor/symfony/http-kernel/Kernel.php:202 (Symfony\Component\HttpKernel\Kernel::handle)
1 src/SimpleSAML/Module.php:234 (SimpleSAML\Module::process)
0 public/module.php:17 (N/A)
```

This is because the `$attributes` array ends up having the authsource config copied to it in addition to the final attributes:

```
array(12) {
  [0]=>
  string(17) "authorizedService"
  [1]=>
  string(9) "gidNumber"
  [2]=>
  string(13) "homeDirectory"
  [3]=>
  string(4) "host"
  [4]=>
  string(3) "uid"
  [5]=>
  string(9) "uidNumber"
  ["authorizedService"]=>
  array(6) {
    <...>
  }
  ["gidNumber"]=>
  array(1) {
    [0]=>
    string(3) "100"
  }
  ["homeDirectory"]=>
  array(1) {
    [0]=>
    string(13) "/home/grawity"
  }
  ["host"]=>
  array(1) {
    [0]=>
    string(1) "*"
  }
  ["uid"]=>
  array(1) {
    [0]=>
    string(7) "grawity"
  }
  ["uidNumber"]=>
  array(1) {
    [0]=>
    string(4) "2001"
  }
}
```