### PR TITLE
Restore the ability to read attributes using a privileged account

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -265,7 +265,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: coverage-data
           path: ${{ github.workspace }}/build

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -283,8 +283,8 @@ jobs:
     runs-on: [ubuntu-latest]
     if: |
       always() &&
-      needs.coverage.result == 'success' ||
-      (needs.unit-tests-linux == 'success' && needs.coverage == 'skipped')
+      needs.coverage.result == 'success' &&
+      (needs.unit-tests-linux == 'success' || needs.coverage == 'skipped')
 
     steps:
       - uses: geekyeggo/delete-artifact@v4

--- a/src/Auth/Process/BaseFilter.php
+++ b/src/Auth/Process/BaseFilter.php
@@ -272,7 +272,7 @@ abstract class BaseFilter extends Auth\ProcessingFilter
         if (is_array($value)) {
             // remove sensitive data
             foreach ($value as $key => &$val) {
-                if ($key === 'search.password') {
+                if ($key === 'search.password' || $key === 'priv.password') {
                     $val = empty($val) ? '' : '********';
                 }
             }

--- a/src/Auth/Source/Ldap.php
+++ b/src/Auth/Source/Ldap.php
@@ -121,7 +121,19 @@ class Ldap extends UserPassBase
             }
         }
 
+        /* Actually verify the credentials. (Must do this unconditionally even if priv.username is set!) */
         $this->connector->bind($dn, $password);
+
+        /* If the credentials were correct, rebind using a privileged account to read attributes */
+        $readUsername = $this->ldapConfig->getOptionalString('priv.username', null);
+        $readPassword = $this->ldapConfig->getOptionalString('priv.password', null);
+        if (!$readUsername) {
+            $readUsername = $this->ldapConfig->getOptionalString('search.username', null);
+            $readPassword = $this->ldapConfig->getOptionalString('search.password', null);
+        }
+        if ($readUsername) {
+            $this->connector->bind($readUsername, $readPassword);
+        }
 
         $options['scope'] = Query::SCOPE_BASE;
         $filter = '(objectClass=*)';

--- a/src/Auth/Source/Ldap.php
+++ b/src/Auth/Source/Ldap.php
@@ -127,11 +127,12 @@ class Ldap extends UserPassBase
         /* If the credentials were correct, rebind using a privileged account to read attributes */
         $readUsername = $this->ldapConfig->getOptionalString('priv.username', null);
         $readPassword = $this->ldapConfig->getOptionalString('priv.password', null);
-        if (!$readUsername) {
+        if ($readUsername === null) {
             $readUsername = $this->ldapConfig->getOptionalString('search.username', null);
             $readPassword = $this->ldapConfig->getOptionalString('search.password', null);
         }
-        if ($readUsername) {
+
+        if ($readUsername !== null) {
             $this->connector->bind($readUsername, $readPassword);
         }
 

--- a/src/Auth/Source/Ldap.php
+++ b/src/Auth/Source/Ldap.php
@@ -121,17 +121,12 @@ class Ldap extends UserPassBase
             }
         }
 
-        /* Actually verify the credentials. (Must do this unconditionally even if priv.username is set!) */
+        /* Verify the credentials */
         $this->connector->bind($dn, $password);
 
         /* If the credentials were correct, rebind using a privileged account to read attributes */
         $readUsername = $this->ldapConfig->getOptionalString('priv.username', null);
         $readPassword = $this->ldapConfig->getOptionalString('priv.password', null);
-        if ($readUsername === null) {
-            $readUsername = $this->ldapConfig->getOptionalString('search.username', null);
-            $readPassword = $this->ldapConfig->getOptionalString('search.password', null);
-        }
-
         if ($readUsername !== null) {
             $this->connector->bind($readUsername, $readPassword);
         }


### PR DESCRIPTION
We have certain attributes that are marked as 'confidential' in AD and therefore can only be read using a privileged account. The ability to do that was lost in commit 2d111bd9c5341273c7b532e5445e63daade4c21e – the settings were read but not used anywhere.

It's almost 5am so this is probably not quite complete, but it did the job.