### PR TITLE
Changes AttributeAddFromLDAP.php to allow search.username and search.password to be optional as is written in the documentation.

### DIFF
--- a/src/Auth/Process/AttributeAddFromLDAP.php
+++ b/src/Auth/Process/AttributeAddFromLDAP.php
@@ -73,8 +73,8 @@ class AttributeAddFromLDAP extends BaseFilter
         $this->attrPolicy = $this->config->getOptionalString('attribute.policy', 'merge');
         Assert::oneOf($this->attrPolicy, ['merge', 'replace', 'add']);
 
-        $this->searchUsername = $this->config->getString('search.username');
-        $this->searchPassword = $this->config->getOptionalString('search.password', null);
+        $this->searchUsername = $this->config->getOptionalString('search.username', '');
+        $this->searchPassword = $this->config->getOptionalString('search.password', '');
     }
 
 


### PR DESCRIPTION
TL;DR: **Changed search.username and search.password to Optionals with an empty string as default, since a string cannot be null.**

I ran into the problem that my config does not need to bind to ldap to do the search. When updating from 1.9.x I ran into an error:

SimpleSAML\Error\UnserializableException: ldap:AuthProcess: Could not retrieve the required option 'search.username'.

This error persisted when specifying, as stated in the ldap documentation.:
```
'search.username' => null, 
'search.password' => null 
```

So I changed the code as in the pull request. Which fixed my problem.

I also tried changing it to this, using null as the default, keeping it more in line with the code in Ldap.php: 
```
$this->searchUsername = $this->config->getOptionalString('search.username', null);
$this->searchPassword = $this->config->getOptionalString('search.password', null);
```
But that also gave me errors:

TypeError: Cannot assign null to property SimpleSAML\Module\ldap\Auth\Process\AttributeAddFromLDAP::$searchUsername of type string
Mar 18 13:08:05 simplesamlphp ERROR [9e2a10f0c2] Backtrace:
Mar 18 13:08:05 simplesamlphp ERROR [9e2a10f0c2] 10 /var/www/simplesamlphp/modules/ldap/src/Auth/Process/AttributeAddFromLDAP.php:77 (SimpleSAML\Module\ldap\Auth\Process\AttributeAddFromLDAP::__construct)

So I went back to the empty strings as default.