### PR TITLE
Adding control checking the orgs in authsources

### DIFF
--- a/src/Auth/Source/LdapMulti.php
+++ b/src/Auth/Source/LdapMulti.php
@@ -119,7 +119,7 @@ class LdapMulti extends UserPassOrgBase
 
         $authsource = $this->mapping[$organization]['authsource'];
 
-        if (array_key_exists($organization, $this->ldapOrgs)) {
+        if (!array_key_exists($organization, $this->ldapOrgs)) {
             // The organization is unknown to us.
             throw new Error\Error('WRONGUSERPASS');
         }


### PR DESCRIPTION
When using multi-ldap, it was not possible to log in correctly because an error always occurred when trying to find the selected organization. As observed in the if condition, the exception is normally triggered when the organization is not found, but, as it was before the change, it was triggered every time it was found