### PR TITLE
Add support for SASL bind

### DIFF
--- a/src/Auth/Source/Ldap.php
+++ b/src/Auth/Source/Ldap.php
@@ -74,7 +74,7 @@ class Ldap extends UserPassBase
      * @param array|null $sasl_args  SASL options
      * @return array  Associative array with the users attributes.
      */
-    protected function loginSasl(string $username, #[\SensitiveParameter]string $password, ?array $sasl_args): array
+    protected function loginSasl(string $username, #[\SensitiveParameter]string $password, array $sasl_args = []): array
     {
         if (preg_match('/^\s*$/', $password)) {
             // The empty string is considered an anonymous bind to Symfony
@@ -129,7 +129,7 @@ class Ldap extends UserPassBase
         }
 
         /* Verify the credentials */
-        if (isset($sasl_args)) {
+        if (empty($sasl_args)) {
             Assert::isArray($sasl_args);
 
             $this->connector->saslBind(

--- a/src/Auth/Source/Ldap.php
+++ b/src/Auth/Source/Ldap.php
@@ -74,7 +74,7 @@ class Ldap extends UserPassBase
      * @param array|null $sasl_args  SASL options
      * @return array  Associative array with the users attributes.
      */
-    protected function login_sasl(string $username, #[\SensitiveParameter]string $password, ?array $sasl_args): array
+    protected function loginSasl(string $username, #[\SensitiveParameter]string $password, ?array $sasl_args): array
     {
         if (preg_match('/^\s*$/', $password)) {
             // The empty string is considered an anonymous bind to Symfony
@@ -132,7 +132,15 @@ class Ldap extends UserPassBase
         if (isset($sasl_args)) {
             Assert::isArray($sasl_args);
 
-            $this->connector->saslBind($dn, $password, $sasl_args['mech'], $sasl_args['realm'], $sasl_args['authc_id'], $sasl_args['authz_id'], $sasl_args['props']);
+            $this->connector->saslBind(
+                $dn,
+                $password,
+                $sasl_args['mech'],
+                $sasl_args['realm'],
+                $sasl_args['authc_id'],
+                $sasl_args['authz_id'],
+                $sasl_args['props'],
+            );
             $dn = $this->connector->whoami();
         } else {
             $this->connector->bind($dn, $password);
@@ -162,7 +170,7 @@ class Ldap extends UserPassBase
      */
     protected function login(string $username, #[\SensitiveParameter]string $password): array
     {
-        return $this->login_sasl($username, $password);
+        return $this->loginSasl($username, $password);
     }
 
 

--- a/src/Auth/Source/LdapMulti.php
+++ b/src/Auth/Source/LdapMulti.php
@@ -134,8 +134,11 @@ class LdapMulti extends UserPassOrgBase
 
         $ldap = new class (['AuthId' => $authsource], $sourceConfig->toArray()) extends Ldap
         {
-            public function loginOverload(string $username, #[\SensitiveParameter]string $password, ?array $sasl_args): array
-            {
+            public function loginOverload(
+                string $username,
+                #[\SensitiveParameter]string $password,
+                ?array $sasl_args,
+            ): array {
                 return $this->loginSasl($username, $password, $sasl_args);
             }
         };

--- a/src/Auth/Source/LdapMulti.php
+++ b/src/Auth/Source/LdapMulti.php
@@ -113,8 +113,12 @@ class LdapMulti extends UserPassOrgBase
      * @param array|null $sasl_args SASL options
      * @return array  Associative array with the users attributes.
      */
-    protected function login_sasl(string $username, #[\SensitiveParameter]string $password, string $organization, ?array $sasl_args): array
-    {
+    protected function loginSasl(
+        string $username,
+        #[\SensitiveParameter]string $password,
+        string $organization,
+        ?array $sasl_args,
+    ): array {
         if ($this->includeOrgInUsername) {
             $username = $username . '@' . $organization;
         }
@@ -132,7 +136,7 @@ class LdapMulti extends UserPassOrgBase
         {
             public function loginOverload(string $username, #[\SensitiveParameter]string $password, ?array $sasl_args): array
             {
-                return $this->login_sasl($username, $password, $sasl_args);
+                return $this->loginSasl($username, $password, $sasl_args);
             }
         };
 
@@ -149,7 +153,7 @@ class LdapMulti extends UserPassOrgBase
      */
     protected function login(string $username, #[\SensitiveParameter]string $password, string $organization): array
     {
-        return $this->login_sasl($username, $password, $organization);
+        return $this->loginSasl($username, $password, $organization);
     }
 
     /**

--- a/src/Auth/Source/LdapMulti.php
+++ b/src/Auth/Source/LdapMulti.php
@@ -105,13 +105,15 @@ class LdapMulti extends UserPassOrgBase
 
 
     /**
-     * Attempt to log in using the given username and password.
+     * Attempt to log in using SASL and the given username and password.
      *
      * @param string $username  The username the user wrote.
      * @param string $password  The password the user wrote.
+     * @param string $organizaion  The organization the user chose.
+     * @param array|null $sasl_args SASL options
      * @return array  Associative array with the users attributes.
      */
-    protected function login(string $username, #[\SensitiveParameter]string $password, string $organization): array
+    protected function login_sasl(string $username, #[\SensitiveParameter]string $password, string $organization, ?array $sasl_args): array
     {
         if ($this->includeOrgInUsername) {
             $username = $username . '@' . $organization;
@@ -128,15 +130,27 @@ class LdapMulti extends UserPassOrgBase
 
         $ldap = new class (['AuthId' => $authsource], $sourceConfig->toArray()) extends Ldap
         {
-            public function loginOverload(string $username, #[\SensitiveParameter]string $password): array
+            public function loginOverload(string $username, #[\SensitiveParameter]string $password, ?array $sasl_args): array
             {
-                return $this->login($username, $password);
+                return $this->login_sasl($username, $password, $sasl_args);
             }
         };
 
-        return $ldap->loginOverload($username, $password);
+        return $ldap->loginOverload($username, $password, $sasl_args);
     }
 
+    /**
+     * Attempt to log in using the given username and password.
+     *
+     * @param string $username  The username the user wrote.
+     * @param string $password  The password the user wrote.
+     * @param string $organizaion  The organization the user chose.
+     * @return array  Associative array with the users attributes.
+     */
+    protected function login(string $username, #[\SensitiveParameter]string $password, string $organization): array
+    {
+        return $this->login_sasl($username, $password, $organization);
+    }
 
     /**
      * Retrieve list of organizations.

--- a/src/Connector/Ldap.php
+++ b/src/Connector/Ldap.php
@@ -112,11 +112,18 @@ class Ldap implements ConnectorInterface
     /**
      * @inheritDoc
      */
-    public function saslBind(?string $username, #[\SensitiveParameter]?string $password, ?string $mech, ?string $realm, ?string $authcId, ?string $authzId, ?string $props): void
-
-    {
-        if (!method_exists($this->connection, 'saslBind'))
+    public function saslBind(
+        ?string $username,
+        #[\SensitiveParameter]?string $password,
+        ?string $mech,
+        ?string $realm,
+        ?string $authcId,
+        ?string $authzId,
+        ?string $props,
+    ): void {
+        if (!method_exists($this->connection, 'saslBind')) {
             throw new Error\Error("SASL not implemented");
+        }
 
         try {
             $this->connection->saslBind($username, strval($password), $mech, $realm, $authcId, $authzId, $props);
@@ -136,8 +143,9 @@ class Ldap implements ConnectorInterface
      */
     public function whoami(): string
     {
-        if (!method_exists($this->connection, 'whoami'))
+        if (!method_exists($this->connection, 'whoami')) {
             throw new Error\Error("SASL not implemented");
+        }
 
         return $this->connection->whoami();
     }

--- a/src/Connector/Ldap.php
+++ b/src/Connector/Ldap.php
@@ -115,6 +115,9 @@ class Ldap implements ConnectorInterface
     public function saslBind(?string $username, #[\SensitiveParameter]?string $password, ?string $mech, ?string $realm, ?string $authcId, ?string $authzId, ?string $props): void
 
     {
+        if (!method_exists($this->connection, 'saslBind'))
+            throw new Error\Error("SASL not implemented");
+
         try {
             $this->connection->saslBind($username, strval($password), $mech, $realm, $authcId, $authzId, $props);
         } catch (InvalidCredentialsException $e) {
@@ -133,6 +136,9 @@ class Ldap implements ConnectorInterface
      */
     public function whoami(): string
     {
+        if (!method_exists($this->connection, 'whoami'))
+            throw new Error\Error("SASL not implemented");
+
         return $this->connection->whoami();
     }
 

--- a/src/Connector/Ldap.php
+++ b/src/Connector/Ldap.php
@@ -109,6 +109,32 @@ class Ldap implements ConnectorInterface
         }
     }
 
+    /**
+     * @inheritDoc
+     */
+    public function saslBind(?string $username, #[\SensitiveParameter]?string $password, ?string $mech, ?string $realm, ?string $authcId, ?string $authzId, ?string $props): void
+
+    {
+        try {
+            $this->connection->saslBind($username, strval($password), $mech, $realm, $authcId, $authzId, $props);
+        } catch (InvalidCredentialsException $e) {
+            throw new Error\Error($this->resolveBindError($e));
+        }
+
+        if ($username === null) {
+            Logger::debug("LDAP bind(): Anonymous bind succesful.");
+        } else {
+            Logger::debug(sprintf("LDAP bind(): Bind successful for DN '%s'.", $username));
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function whoami(): string
+    {
+        return $this->connection->whoami();
+    }
 
     /**
      * @inheritDoc

--- a/src/ConnectorInterface.php
+++ b/src/ConnectorInterface.php
@@ -49,7 +49,7 @@ interface ConnectorInterface
         ?string $realm,
         ?string $authcId,
         ?string $authzId,
-        ?string $props
+        ?string $props,
     ): void;
 
 

--- a/src/ConnectorInterface.php
+++ b/src/ConnectorInterface.php
@@ -33,7 +33,7 @@ interface ConnectorInterface
      *
      * @param string|null $username
      * @param string|null $password Null for passwordless logon
-     * @param string|null $mech 
+     * @param string|null $mech
      * @param string|null $realm
      * @param string|null $authcId
      * @param string|null $authzId

--- a/src/ConnectorInterface.php
+++ b/src/ConnectorInterface.php
@@ -29,6 +29,39 @@ interface ConnectorInterface
 
 
     /**
+     * Bind to an LDAP-server using SASL
+     *
+     * @param string|null $username
+     * @param string|null $password Null for passwordless logon
+     * @param string|null $mech 
+     * @param string|null $realm
+     * @param string|null $authcId
+     * @param string|null $authzId
+     * @param string|null $props
+     * @return void
+     *
+     * @throws \SimpleSAML\Error\Exception if none of the LDAP-servers could be contacted
+     */
+    public function saslBind(
+        ?string $username,
+        ?string $password,
+        ?string $mech,
+        ?string $realm,
+        ?string $authcId,
+        ?string $authzId,
+        ?string $props
+    ): void;
+
+
+    /**
+     * Return the authenticated DN
+     *
+     * @return string
+     */
+    public function whoami(): string;
+
+
+    /**
      * Search the LDAP-directory for a specific object
      *
      * @param array $searchBase


### PR DESCRIPTION
We introduce a ldap_sasl() method in Ldap and LdapMulti with an optionnal array of SASL options. A module that subclasses Ldap or Ldapmulti can use it instead of simple login().

This requires SASL bind support in Symfony, which has been merged in the 7.3 branch. SimpleSAMLphp uses Symfony 7.2. How should this ne handled? I can backport the patches for Symfony 7.2, but do we have a way to fold them in the simpleSAMLphp package?